### PR TITLE
Fix Random Phone Number Generation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/Pallinder/go-randomdata
+
+go 1.18
+
+require golang.org/x/text v0.3.7

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=

--- a/random_data.go
+++ b/random_data.go
@@ -428,8 +428,26 @@ func UserAgentString() string {
 }
 
 func PhoneNumber() string {
-	str := randomFrom(jsonData.CountryCallingCodes) + " "
+	randCountryCode := randomFrom(jsonData.CountryCallingCodes)
 
+	if randCountryCode == " " {
+		//fmt.Println("replaced space")
+		randCountryCode = "1"
+	}
+
+	// The jsondata origin file https://github.com/datasets/country-codes/blob/master/data/country-codes.csv
+	// contains multiple country codes for the Dominican Republic, separated by commas. This addresses that unique
+	// edge case here instead of there as the JSON could be accidentally overwritten.
+	if strings.Contains(randCountryCode, ",") {
+		//fmt.Println("split commas")
+		possibleCountryCodes := strings.Split(randCountryCode, ",")
+		randIdx := privateRand.Intn(len(possibleCountryCodes))
+		randCountryCode = possibleCountryCodes[randIdx]
+	}
+
+	str := randCountryCode + " "
+
+	//str := randomFrom(jsonData.CountryCallingCodes) + " "
 	str += Digits(privateRand.Intn(3) + 1)
 
 	for {

--- a/random_data.go
+++ b/random_data.go
@@ -430,8 +430,9 @@ func UserAgentString() string {
 func PhoneNumber() string {
 	randCountryCode := randomFrom(jsonData.CountryCallingCodes)
 
+	// The jsondata origin file https://github.com/datasets/country-codes/blob/master/data/country-codes.csv
+	// contains an empty space for the US territories. As a result, this hard codes it to 1
 	if randCountryCode == " " {
-		//fmt.Println("replaced space")
 		randCountryCode = "1"
 	}
 
@@ -439,7 +440,6 @@ func PhoneNumber() string {
 	// contains multiple country codes for the Dominican Republic, separated by commas. This addresses that unique
 	// edge case here instead of there as the JSON could be accidentally overwritten.
 	if strings.Contains(randCountryCode, ",") {
-		//fmt.Println("split commas")
 		possibleCountryCodes := strings.Split(randCountryCode, ",")
 		randIdx := privateRand.Intn(len(possibleCountryCodes))
 		randCountryCode = possibleCountryCodes[randIdx]

--- a/random_data.go
+++ b/random_data.go
@@ -447,7 +447,6 @@ func PhoneNumber() string {
 
 	str := randCountryCode + " "
 
-	//str := randomFrom(jsonData.CountryCallingCodes) + " "
 	str += Digits(privateRand.Intn(3) + 1)
 
 	for {


### PR DESCRIPTION
*Background*
We've seen an uptick in flaky tests due to this random phone number generator. The generated numbers, once passed through the Golang lib-phonenumbers equivalent fails. Using the sample script, we were able to isolate 2 specific data issues:

- Numbers that contain a `,` in them. This is invalid — for obvious reasons that there's no commas on a phone. Somehow, I didn't really realize that until much later.
- Numbers that have an empty space as the country code. Again, invalid again for obvious reasons.

It turns out there's a reason for this, they both exist as inputs [here](https://github.com/Pallinder/go-randomdata/blob/26f4a641b55b152ed383ba02b30b99763401ade3/jsondata.go#L2726)
- The comma is actually a comma separated list of possible country codes from the Dominican Republic
- The empty space corresponds to US territories.

We could've also fixed this in the actual JSON data, but I think this data comes from a script that is generated from this [CSV](https://github.com/datasets/country-codes/blob/master/data/country-codes.csv). We would need to fix the CSV script and then update the imported data, but that may have larger unintentional consequences on other usages of the library. Instead, we opted for handling edge cases + commenting it here.

In the following script:
- Original code: ~4800 failures/1 mil = .5%
- New code: ~4 failures/1 mil = ... a small number

Sample script:
```
	count := 0
	for i := 0; i < 1000000; i++ {
		val := randomdata.PhoneNumber()
		err := go_validator.ValidatePhone(val, "")
		if err != nil {
			count++
			fmt.Println("error")
		}
	}

	fmt.Println("Number failures: ", count)
```
